### PR TITLE
ensure that CMake requests at least -std=c++17 from the compiler

### DIFF
--- a/elf2rel/CMakeLists.txt
+++ b/elf2rel/CMakeLists.txt
@@ -7,4 +7,5 @@ target_include_directories( elf2rel PRIVATE
   ${CMAKE_CURRENT_LIST_DIR})
 
 find_package(Boost REQUIRED COMPONENTS program_options)
-target_link_libraries(elf2rel Boost::program_options )
+target_link_libraries(elf2rel Boost::program_options)
+target_compile_features(elf2rel PUBLIC cxx_std_17)


### PR DESCRIPTION
the codebase uses range-based for, `std::map::merge`, etc. fixes build on non-windows targets.